### PR TITLE
feat: bump proposal desc and ref limit

### DIFF
--- a/src/util/proposal/manageProposals.ts
+++ b/src/util/proposal/manageProposals.ts
@@ -33,7 +33,7 @@ const description = () =>
 		.setPlaceholder("Add a suiting description!")
 		.setStyle(TextInputStyle.Paragraph)
 		.setMinLength(20)
-		.setMaxLength(200);
+		.setMaxLength(500);
 
 const duration = () =>
 	new TextInputBuilder()
@@ -52,7 +52,7 @@ const references = () =>
 			"Add any references you may have like links to videos! (please make it a pretty bullet list)"
 		)
 		.setStyle(TextInputStyle.Paragraph)
-		.setMaxLength(200)
+		.setMaxLength(500)
 		.setRequired(false);
 
 export async function addProposal(interaction: ChatInputCommandInteraction): Promise<void> {


### PR DESCRIPTION
Bumps the proposal limits for the description and refrence. 

Math is here 
```
Uses: 

listProposals.ts L90
desc: desc field (all by self) 4096 chr
refrences: field body by self 1024 chr

jamEvents.ts L18
desc: event desc `for the ${jam.title}.\n${proposal.description}`
1000 - 10 (`for the .\n`) - 60 (title) = 930

L30 
desc: field body by self 1024 chr
refrences: field body by self 1024 chr

pollEvent.ts L 53
desc: field body by self 1024 chr

L127 
field body `${winner.description}\n${winner.references}`
(1024 - 1) / 2 = 511.5

listProposals.ts L47
field body `${proposal.description}${proposal.references != "" ? `\n${proposal.references}` : ""}`
(1024 - 1) / 2 = 511.5
```

