### PR TITLE
fix: user info

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"prettify": "eslint ./src/ --fix && npx prettier -w .",
 		"build": "tsc -p tsconfig.json",
-		"run": "node --experimental-specifier-resolution=node .",
+		"run": "node --experimental-specifier-resolution=node --enable-source-maps .",
 		"start": "npm run build && npm run run",
 		"prepare": "husky install"
 	},

--- a/src/commands/UserInfoCommand.ts
+++ b/src/commands/UserInfoCommand.ts
@@ -55,8 +55,7 @@ const badges = {
 function getUserEmbed(user: User, member: GuildMember | null | undefined): EmbedBuilder {
 	const embed = new EmbedBuilder()
 		.setTitle(
-			`${user.tag} ${member ? "aka. " + member.displayName : ""} ${
-				user.system ? "| System" : user.bot ? "| Bot" : ""
+			`${user.discriminator === '0' ? user.username : user.tag}${member?.nickname ? " aka. " + member.nickname : ""} ${user.system ? "| System" : user.bot ? "| Bot" : ""
 			}`
 		)
 		.setThumbnail(user.displayAvatarURL({ size: 1024, extension: "png" }))
@@ -95,12 +94,13 @@ function getUserEmbed(user: User, member: GuildMember | null | undefined): Embed
 				name: "Discord Badges",
 				value: user.flags
 					.toArray()
+					.filter(v => !v.match(/^\d+$/))
 					.map((v) => badges[v as keyof typeof badges] || v.replace(/[A-Z0-9]/g, " $&").trim())
 					.join(", "),
 			});
 		}
-
-		embed.addFields({ name: "Roles", value: roles });
+		if (roles)
+			embed.addFields({ name: "Roles", value: roles });
 	}
 	return addEmbedFooter(embed);
 }


### PR DESCRIPTION
- Doesn't show discrim on pomelo usernames
- Doesn't show aka when no nick
- Fix crash with no roles
- Doesn't show badge bitfield values

Note: Display names are currently not possible, do to lack of d.js support. When this change is pushed, we can also remove the tag check.

I also enabled source maps on run cause it was annoying me